### PR TITLE
Document `completeProvider` as optional in data.min.json

### DIFF
--- a/content/specs/rules.md
+++ b/content/specs/rules.md
@@ -29,7 +29,7 @@ Every provider has the parent element **providers**, it holds the reference to a
 Every provider has the following properties:
 
 - `urlPattern` (required)
-- `completeProvider` (required)
+- `completeProvider` (optional)
 - `rules` (optional)
 - `rawRules` (optional)
 - `referralMarketing` (optional)


### PR DESCRIPTION
`completeProvider`is unset when not true in data.min.json, as such it's not a required property.